### PR TITLE
Add LLM agents with persistent memory

### DIFF
--- a/LLM/__init__.py
+++ b/LLM/__init__.py
@@ -4,6 +4,7 @@ from .rag_agent import RAGAgent
 from .finetuned_agent import FinetunedAgent
 from .rag_finetuned_agent import RAGFinetunedAgent
 from .memory_db import TrajectoryDatabase
+from .langraph_utils import build_generation_graph
 
 __all__ = [
     "BaseLLMAgent",
@@ -12,4 +13,5 @@ __all__ = [
     "FinetunedAgent",
     "RAGFinetunedAgent",
     "TrajectoryDatabase",
+    "build_generation_graph",
 ]

--- a/LLM/__init__.py
+++ b/LLM/__init__.py
@@ -1,0 +1,15 @@
+from .base import BaseLLMAgent
+from .one_shot_agent import OneShotAgent
+from .rag_agent import RAGAgent
+from .finetuned_agent import FinetunedAgent
+from .rag_finetuned_agent import RAGFinetunedAgent
+from .memory_db import TrajectoryDatabase
+
+__all__ = [
+    "BaseLLMAgent",
+    "OneShotAgent",
+    "RAGAgent",
+    "FinetunedAgent",
+    "RAGFinetunedAgent",
+    "TrajectoryDatabase",
+]

--- a/LLM/base.py
+++ b/LLM/base.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from CybORG.Agents import BaseAgent
+from .memory_db import TrajectoryDatabase
+
+
+class BaseLLMAgent(BaseAgent):
+    """Base class for LLM-driven agents with trajectory logging."""
+
+    def __init__(self, db: TrajectoryDatabase | None = None) -> None:
+        super().__init__()
+        self.db = db or TrajectoryDatabase()
+
+    def _log_transition(self, state, action, reward: float) -> None:
+        if self.db:
+            self.db.insert(state, action, reward)
+
+    def end_episode(self) -> None:
+        pass

--- a/LLM/finetuned_agent.py
+++ b/LLM/finetuned_agent.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Any
+
+try:
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+    import torch
+except Exception:  # pragma: no cover - optional dependency
+    AutoModelForCausalLM = None
+    AutoTokenizer = None
+    torch = None
+
+from .base import BaseLLMAgent
+
+
+def _load_default_model():
+    if AutoModelForCausalLM is None:
+        raise ImportError("transformers is required for LLM agents")
+    model_name = "distilgpt2"
+    model = AutoModelForCausalLM.from_pretrained(model_name)
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model.to(device)
+    return model, tokenizer, device
+
+
+class FinetunedAgent(BaseLLMAgent):
+    """Agent that assumes the underlying model has been fine-tuned."""
+
+    def __init__(self, *args: Any, model=None, tokenizer=None, device=None, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        if model is None or tokenizer is None:
+            model, tokenizer, device = _load_default_model()
+        self.model = model
+        self.tokenizer = tokenizer
+        self.device = device
+
+    def get_action(self, observation, action_space=None, hidden=None):
+        prompt = f"State: {observation}\nAction:"
+        inputs = self.tokenizer(prompt, return_tensors="pt").to(self.device)
+        output = self.model.generate(**inputs, max_new_tokens=1)
+        text = self.tokenizer.decode(output[0], skip_special_tokens=True)
+        try:
+            return int(text.strip().split()[-1])
+        except Exception:
+            return 0
+
+    def train(self, results):
+        self._log_transition(results.observation, results.action, results.reward)

--- a/LLM/langraph_utils.py
+++ b/LLM/langraph_utils.py
@@ -1,0 +1,27 @@
+try:
+    from langgraph.graph import StateGraph
+except Exception:  # pragma: no cover - optional dependency
+    StateGraph = None
+
+
+def build_generation_graph(model, tokenizer, device):
+    """Return a Langraph graph that generates a single action token."""
+    if StateGraph is None:
+        raise ImportError("langraph is required for LLM agents")
+
+    from typing import Dict
+
+    # Define the transformation function used by the single node
+    def generate_fn(data: Dict[str, str]) -> Dict[str, str]:
+        prompt = data["prompt"]
+        inputs = tokenizer(prompt, return_tensors="pt").to(device)
+        output = model.generate(**inputs, max_new_tokens=1)
+        text = tokenizer.decode(output[0], skip_special_tokens=True)
+        return {"action": text}
+
+    # Build a minimal state graph with one node
+    graph = StateGraph(input_schema={"prompt": str}, output_schema={"action": str})
+    graph.add_node("generate", generate_fn)
+    graph.set_entry_point("generate")
+    graph.set_finish_point("generate")
+    return graph.compile()

--- a/LLM/memory_db.py
+++ b/LLM/memory_db.py
@@ -1,0 +1,40 @@
+import sqlite3
+import json
+from typing import Iterable, Tuple
+
+
+class TrajectoryDatabase:
+    """Simple SQLite backend to store agent transitions."""
+
+    def __init__(self, path: str = "trajectories.db") -> None:
+        self.conn = sqlite3.connect(path)
+        self._setup()
+
+    def _setup(self) -> None:
+        cur = self.conn.cursor()
+        cur.execute(
+            "CREATE TABLE IF NOT EXISTS transitions("
+            "id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            "state TEXT,"
+            "action TEXT,"
+            "reward REAL"
+            ")"
+        )
+        self.conn.commit()
+
+    def insert(self, state, action, reward: float) -> None:
+        cur = self.conn.cursor()
+        cur.execute(
+            "INSERT INTO transitions(state, action, reward) VALUES (?, ?, ?)",
+            (json.dumps(state), json.dumps(action), float(reward)),
+        )
+        self.conn.commit()
+
+    def all_transitions(self) -> Iterable[Tuple[dict, dict, float]]:
+        cur = self.conn.cursor()
+        cur.execute("SELECT state, action, reward FROM transitions")
+        for s, a, r in cur.fetchall():
+            yield json.loads(s), json.loads(a), r
+
+    def close(self) -> None:
+        self.conn.close()

--- a/LLM/one_shot_agent.py
+++ b/LLM/one_shot_agent.py
@@ -11,6 +11,7 @@ except Exception:  # pragma: no cover - optional dependency
     torch = None
 
 from .base import BaseLLMAgent
+from .langraph_utils import build_generation_graph
 
 
 def _load_default_model():
@@ -34,12 +35,20 @@ class OneShotAgent(BaseLLMAgent):
         self.model = model
         self.tokenizer = tokenizer
         self.device = device
+        try:
+            self.graph = build_generation_graph(self.model, self.tokenizer, self.device)
+        except Exception:  # pragma: no cover - optional dependency
+            self.graph = None
 
     def get_action(self, observation, action_space=None, hidden=None):
         prompt = f"State: {observation}\nAction:"
-        inputs = self.tokenizer(prompt, return_tensors="pt").to(self.device)
-        output = self.model.generate(**inputs, max_new_tokens=1)
-        text = self.tokenizer.decode(output[0], skip_special_tokens=True)
+        if self.graph:
+            result = self.graph.invoke({"prompt": prompt})
+            text = result.get("action", "0")
+        else:
+            inputs = self.tokenizer(prompt, return_tensors="pt").to(self.device)
+            output = self.model.generate(**inputs, max_new_tokens=1)
+            text = self.tokenizer.decode(output[0], skip_special_tokens=True)
         try:
             return int(text.strip().split()[-1])
         except Exception:

--- a/LLM/one_shot_agent.py
+++ b/LLM/one_shot_agent.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Any
+
+try:
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+    import torch
+except Exception:  # pragma: no cover - optional dependency
+    AutoModelForCausalLM = None
+    AutoTokenizer = None
+    torch = None
+
+from .base import BaseLLMAgent
+
+
+def _load_default_model():
+    if AutoModelForCausalLM is None:
+        raise ImportError("transformers is required for LLM agents")
+    model_name = "distilgpt2"
+    model = AutoModelForCausalLM.from_pretrained(model_name)
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model.to(device)
+    return model, tokenizer, device
+
+
+class OneShotAgent(BaseLLMAgent):
+    """Simple one-shot LLM agent."""
+
+    def __init__(self, *args: Any, model=None, tokenizer=None, device=None, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        if model is None or tokenizer is None:
+            model, tokenizer, device = _load_default_model()
+        self.model = model
+        self.tokenizer = tokenizer
+        self.device = device
+
+    def get_action(self, observation, action_space=None, hidden=None):
+        prompt = f"State: {observation}\nAction:"
+        inputs = self.tokenizer(prompt, return_tensors="pt").to(self.device)
+        output = self.model.generate(**inputs, max_new_tokens=1)
+        text = self.tokenizer.decode(output[0], skip_special_tokens=True)
+        try:
+            return int(text.strip().split()[-1])
+        except Exception:
+            return 0
+
+    def train(self, results):
+        self._log_transition(results.observation, results.action, results.reward)

--- a/LLM/rag_agent.py
+++ b/LLM/rag_agent.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from typing import Any
+
+try:
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+    import torch
+except Exception:  # pragma: no cover - optional dependency
+    AutoModelForCausalLM = None
+    AutoTokenizer = None
+    torch = None
+
+from .base import BaseLLMAgent
+from .memory_db import TrajectoryDatabase
+
+
+def _load_default_model():
+    if AutoModelForCausalLM is None:
+        raise ImportError("transformers is required for LLM agents")
+    model_name = "distilgpt2"
+    model = AutoModelForCausalLM.from_pretrained(model_name)
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model.to(device)
+    return model, tokenizer, device
+
+
+class RAGAgent(BaseLLMAgent):
+    """Retrieval Augmented Generation agent."""
+
+    def __init__(self, *args: Any, db: TrajectoryDatabase | None = None, model=None, tokenizer=None, device=None, **kwargs: Any) -> None:
+        super().__init__(db=db)
+        if model is None or tokenizer is None:
+            model, tokenizer, device = _load_default_model()
+        self.model = model
+        self.tokenizer = tokenizer
+        self.device = device
+
+    def _build_context(self, observation: Any) -> str:
+        """Retrieve past transitions to build context for the LLM."""
+        context = []
+        if self.db:
+            for s, a, r in list(self.db.all_transitions())[-5:]:
+                context.append(f"State: {s} Action: {a} Reward: {r}")
+        context.append(f"Current state: {observation}")
+        return "\n".join(context)
+
+    def get_action(self, observation, action_space=None, hidden=None):
+        prompt = self._build_context(observation) + "\nAction:"
+        inputs = self.tokenizer(prompt, return_tensors="pt").to(self.device)
+        output = self.model.generate(**inputs, max_new_tokens=1)
+        text = self.tokenizer.decode(output[0], skip_special_tokens=True)
+        try:
+            return int(text.strip().split()[-1])
+        except Exception:
+            return 0
+
+    def train(self, results):
+        self._log_transition(results.observation, results.action, results.reward)

--- a/LLM/rag_finetuned_agent.py
+++ b/LLM/rag_finetuned_agent.py
@@ -12,6 +12,7 @@ except Exception:  # pragma: no cover - optional dependency
 
 from .base import BaseLLMAgent
 from .memory_db import TrajectoryDatabase
+from .langraph_utils import build_generation_graph
 
 
 def _load_default_model():
@@ -35,6 +36,10 @@ class RAGFinetunedAgent(BaseLLMAgent):
         self.model = model
         self.tokenizer = tokenizer
         self.device = device
+        try:
+            self.graph = build_generation_graph(self.model, self.tokenizer, self.device)
+        except Exception:  # pragma: no cover - optional dependency
+            self.graph = None
 
     def _build_context(self, observation: Any) -> str:
         context = []
@@ -46,9 +51,13 @@ class RAGFinetunedAgent(BaseLLMAgent):
 
     def get_action(self, observation, action_space=None, hidden=None):
         prompt = self._build_context(observation) + "\nAction:"
-        inputs = self.tokenizer(prompt, return_tensors="pt").to(self.device)
-        output = self.model.generate(**inputs, max_new_tokens=1)
-        text = self.tokenizer.decode(output[0], skip_special_tokens=True)
+        if self.graph:
+            result = self.graph.invoke({"prompt": prompt})
+            text = result.get("action", "0")
+        else:
+            inputs = self.tokenizer(prompt, return_tensors="pt").to(self.device)
+            output = self.model.generate(**inputs, max_new_tokens=1)
+            text = self.tokenizer.decode(output[0], skip_special_tokens=True)
         try:
             return int(text.strip().split()[-1])
         except Exception:

--- a/LLM/rag_finetuned_agent.py
+++ b/LLM/rag_finetuned_agent.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import Any
+
+try:
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+    import torch
+except Exception:  # pragma: no cover - optional dependency
+    AutoModelForCausalLM = None
+    AutoTokenizer = None
+    torch = None
+
+from .base import BaseLLMAgent
+from .memory_db import TrajectoryDatabase
+
+
+def _load_default_model():
+    if AutoModelForCausalLM is None:
+        raise ImportError("transformers is required for LLM agents")
+    model_name = "distilgpt2"
+    model = AutoModelForCausalLM.from_pretrained(model_name)
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model.to(device)
+    return model, tokenizer, device
+
+
+class RAGFinetunedAgent(BaseLLMAgent):
+    """Agent that combines retrieval with a fine-tuned model."""
+
+    def __init__(self, *args: Any, db: TrajectoryDatabase | None = None, model=None, tokenizer=None, device=None, **kwargs: Any) -> None:
+        super().__init__(db=db)
+        if model is None or tokenizer is None:
+            model, tokenizer, device = _load_default_model()
+        self.model = model
+        self.tokenizer = tokenizer
+        self.device = device
+
+    def _build_context(self, observation: Any) -> str:
+        context = []
+        if self.db:
+            for s, a, r in list(self.db.all_transitions())[-5:]:
+                context.append(f"State: {s} Action: {a} Reward: {r}")
+        context.append(f"Current state: {observation}")
+        return "\n".join(context)
+
+    def get_action(self, observation, action_space=None, hidden=None):
+        prompt = self._build_context(observation) + "\nAction:"
+        inputs = self.tokenizer(prompt, return_tensors="pt").to(self.device)
+        output = self.model.generate(**inputs, max_new_tokens=1)
+        text = self.tokenizer.decode(output[0], skip_special_tokens=True)
+        try:
+            return int(text.strip().split()[-1])
+        except Exception:
+            return 0
+
+    def train(self, results):
+        self._log_transition(results.observation, results.action, results.reward)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ core training loop simple.
 ## LLM Agents
 
 The `LLM` package contains experimental agents that make decisions with large
-language models. Four strategies are provided:
+language models. The agents are orchestrated using the `langgraph` library to
+manage the prompt generation flow. Four strategies are provided:
 
 1. **OneShotAgent** – prompts an LLM for an action given the current state.
 2. **RAGAgent** – augments the prompt with recently observed transitions.
@@ -42,3 +43,5 @@ language models. Four strategies are provided:
 
 All agents log the observed state, chosen action and reward to a small SQLite
 database via `TrajectoryDatabase`.
+The `langgraph` package is an optional dependency used to construct the
+generation graphs for these agents.

--- a/README.md
+++ b/README.md
@@ -27,3 +27,18 @@ driven exploration:
 
 These steps allow you to extend the base agent with curiosity while keeping its
 core training loop simple.
+
+## LLM Agents
+
+The `LLM` package contains experimental agents that make decisions with large
+language models. Four strategies are provided:
+
+1. **OneShotAgent** – prompts an LLM for an action given the current state.
+2. **RAGAgent** – augments the prompt with recently observed transitions.
+3. **FinetunedAgent** – assumes the underlying model has been fine-tuned on
+   relevant data.
+4. **RAGFinetunedAgent** – combines retrieval augmented prompts with a
+   fine-tuned model.
+
+All agents log the observed state, chosen action and reward to a small SQLite
+database via `TrajectoryDatabase`.

--- a/Requirements.txt
+++ b/Requirements.txt
@@ -10,3 +10,4 @@ tensorboard>=2.15
 tensorboardX>=2.6
 scikit-learn>=1.4
 matplotlib>=3.8
+langgraph>=0.0.5


### PR DESCRIPTION
## Summary
- implement a new `LLM` package
- add `TrajectoryDatabase` for saving state/action/reward data
- implement OneShot, RAG, Finetuned and RAG+Finetuned agents
- document the new agents in `README`

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b2ef9a5888323b6a881da0a170d8e